### PR TITLE
Give nodes an data-node-id property to allow them to be themed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ When loading as a module, you can also access these charts as properties, so
 instead of `new Sankey(g)` you'd use `new Sankey.Selection(g)`;
 
 
+### Special theming
+
+If you add a property to a node object named "id", d3.chart.sankey will add an
+HTML attribute named "data-node-id" with the value of the "id" property to the
+node's `<g>` tag.
+
+This allows CSS and non-D3 JavaScript code to target the node with a selector.
+For example, in CSS:
+
+```
+[data-node-id="some-id"] rect {
+  fill: red;
+}
+```
+
+... or in JavaScript...
+
+```
+document.querySelectorAll('[data-node-id="some-id"]');
+```
+
+
 ## Building
 
 You'll need [Node.js](http://nodejs.org/), [Grunt](http://gruntjs.com/) and [Bower](http://bower.io/). To fetch required dependencies, run the following commands from the root of this repository:

--- a/d3.chart.sankey.js
+++ b/d3.chart.sankey.js
@@ -144,7 +144,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 
 	      insert: function() {
-	        return this.append("g").classed("node", true);
+	        return this.append("g").classed("node", true).attr('data-node-id', function(d) {
+	          return d.id;
+	        });
 	      },
 
 	      events: {

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -66,7 +66,9 @@ module.exports = Base.extend("Sankey", {
       },
 
       insert: function() {
-        return this.append("g").classed("node", true);
+        return this.append("g").classed("node", true).attr('data-node-id', function(d) {
+          return d.id;
+        });
       },
 
       events: {


### PR DESCRIPTION
# Problem / motivation

> As a themer, I want certain nodes in a rendered diagram to have an identifier, so that I can assign CSS to these nodes.
> 
> As a developer, I want certain nodes in a rendered diagram to have an identifier that I can select with JavaScript, so that I can add dynamic behaviors to them without necessarily integrating directly with the D3 library.

Currently, once a diagram has been rendered, the nodes in the diagram have no "identifying features" to allow CSS, or non-D3 JavaScript to target them directly.

# Proposed resolution

This pull request looks for an `id` property in the node object. If one exists, then it adds a `data-node-id` attribute to the node's `<g>` tag.

This allows CSS and non-D3 JavaScript code to target the node with a selector. For example, in CSS:

```
[data-node-id="some-id"] rect {
  fill: red;
}
```

... or in JavaScript...

```
document.querySelectorAll('[data-node-id="some-id"]');
```

# Remaining tasks

- [ ] Approve change
- [ ] Code review
- [ ] Commit
